### PR TITLE
Add shared async client helper

### DIFF
--- a/perplexity-openai-agents-sdk/README.md
+++ b/perplexity-openai-agents-sdk/README.md
@@ -29,6 +29,7 @@ Set the following environment variables or update the code with the appropriate 
 	•	`EXAMPLE_BASE_URL`: The base URL of the Perplexity API (default: https://api.perplexity.ai).
 	•	`EXAMPLE_API_KEY`: Your API key for accessing the Sonar API.
 	•	`EXAMPLE_MODEL_NAME`: The model name, defaulting to `sonar-pro`.
+        •       `EXAMPLE_API_VERSION`: Optional API version, defaults to `v1`.
 
 ## Usage
 
@@ -37,7 +38,7 @@ Simply run the script to create the agent and test a sample query asking for the
 
 ## Running the Example
 	1.	Set up Environment Variables:
-Ensure `EXAMPLE_BASE_URL`, `EXAMPLE_API_KEY`, and `EXAMPLE_MODEL_NAME` are set, either in your shell or within the code.
+Ensure `EXAMPLE_BASE_URL`, `EXAMPLE_API_KEY`, and `EXAMPLE_MODEL_NAME`, `EXAMPLE_API_VERSION` are set, either in your shell or within the code.
 	2.	Install Dependencies:
 Make sure you have installed the required packages (`openai`, `nest_asyncio`, and `agents`).
 	3.	Execute the Script:

--- a/perplexity-openai-agents-sdk/client_helper.py
+++ b/perplexity-openai-agents-sdk/client_helper.py
@@ -1,0 +1,21 @@
+import os
+from openai import AsyncOpenAI
+
+DEFAULT_BASE_URL = os.getenv("EXAMPLE_BASE_URL") or "https://api.perplexity.ai"
+DEFAULT_API_KEY = os.getenv("EXAMPLE_API_KEY")
+API_VERSION = os.getenv("EXAMPLE_API_VERSION") or "v1"
+
+def get_async_client(
+    base_url: str | None = None,
+    api_key: str | None = None,
+    api_version: str | None = None,
+) -> AsyncOpenAI:
+    """Return a shared AsyncOpenAI client configured for the Sonar API."""
+    base_url = base_url or DEFAULT_BASE_URL
+    api_key = api_key or DEFAULT_API_KEY
+    api_version = api_version or API_VERSION
+    if not api_key:
+        raise ValueError("EXAMPLE_API_KEY must be set via environment or argument")
+    if api_version and not base_url.rstrip("/").endswith(api_version):
+        base_url = base_url.rstrip("/") + f"/{api_version}"
+    return AsyncOpenAI(base_url=base_url, api_key=api_key)

--- a/perplexity-openai-agents-sdk/pplx_openai.py
+++ b/perplexity-openai-agents-sdk/pplx_openai.py
@@ -4,6 +4,7 @@ import os       # To access environment variables
 
 # Import AsyncOpenAI for creating an async client
 from openai import AsyncOpenAI
+from client_helper import get_async_client
 
 # Import custom classes and functions from the agents package.
 # These handle agent creation, model interfacing, running agents, and more.
@@ -11,8 +12,9 @@ from agents import Agent, OpenAIChatCompletionsModel, Runner, function_tool, set
 
 # Retrieve configuration from environment variables or use defaults
 BASE_URL = os.getenv("EXAMPLE_BASE_URL") or "https://api.perplexity.ai"
-API_KEY = os.getenv("EXAMPLE_API_KEY") 
+API_KEY = os.getenv("EXAMPLE_API_KEY")
 MODEL_NAME = os.getenv("EXAMPLE_MODEL_NAME") or "sonar-pro"
+API_VERSION = os.getenv("EXAMPLE_API_VERSION") or "v1"
 
 # Validate that all required configuration variables are set
 if not BASE_URL or not API_KEY or not MODEL_NAME:
@@ -29,8 +31,9 @@ Note: Tracing is disabled in this example. If you have an OpenAI platform API ke
 you can enable tracing by setting the environment variable OPENAI_API_KEY or using set_tracing_export_api_key().
 """
 
-# Initialize the custom OpenAI async client with the specified BASE_URL and API_KEY.
-client = AsyncOpenAI(base_url=BASE_URL, api_key=API_KEY)
+# Initialize the custom OpenAI async client using the helper. This allows
+# sharing a single HTTP client instance and supports API versioning.
+client = get_async_client(base_url=BASE_URL, api_key=API_KEY, api_version=API_VERSION)
 
 # Disable tracing to avoid using a platform tracing key; adjust as needed.
 set_tracing_disabled(disabled=True)


### PR DESCRIPTION
## Summary
- implement `client_helper` for an async OpenAI client
- update example to use the helper and allow API version selection
- document the `EXAMPLE_API_VERSION` variable

## Testing
- `python -m py_compile perplexity-openai-agents-sdk/pplx_openai.py perplexity-openai-agents-sdk/client_helper.py`