### PR TITLE
Fix minor README typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,8 @@ We're especially interested in projects that demonstrate one or more of the foll
 2. **Create a New Directory**: Name it descriptively after your project
 3. **Implement Your Project**: Follow the quality guidelines above
 4. **Test Thoroughly**: Ensure everything works as expected
-5. **Update the README**: Add your project to the README for visibility. 
-5. **Submit a Pull Request**: Include a detailed description of your project and what makes it valuable
+5. **Update the README**: Add your project to the README for visibility.
+6. **Submit a Pull Request**: Include a detailed description of your project and what makes it valuable
 
 ## Review Criteria
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ Please check the [CONTRIBUTING.md](./CONTRIBUTING.md) file for guidelines.
 
 • **[Daily Knowledge Bot](sonar-use-cases/daily_knowledge_bot/)** - Python application that delivers interesting facts about rotating topics using the Perplexity AI API.
 
-• **[Disease Information App](sonar-use-cases/daily_knowledge_bot/)** - Interactive browser-based application providing structured information about diseases using the Sonar API.
+• **[Disease Information App](sonar-use-cases/disease_qa/)** - Interactive browser-based application providing structured information about diseases using the Sonar API.
 
 ## Getting Started
 
 To use any of the projects in this repository, you'll need:
 
 1. A Perplexity API key (sign up [here](https://docs.perplexity.ai/guides/getting-started))
-3. Python 3.7+ installed on your system
+2. Python 3.7+ installed on your system
 
 Each project includes its own README with specific installation and usage instructions.
 

--- a/perplexity-llamaindex/memory/README.md
+++ b/perplexity-llamaindex/memory/README.md
@@ -43,7 +43,7 @@ memory/
 
 ## Contributions
 
-If you have found another way to do tackle the same issue using LlamaIndex please feel free to open a PR! Check out our `CONTRIBUTING.md` file for more guidance. 
+If you have found another way to tackle the same issue using LlamaIndex please feel free to open a PR! Check out our `CONTRIBUTING.md` file for more guidance.
 
 ---
 


### PR DESCRIPTION
## Summary
- correct Disease Information App path
- fix numbering in Getting Started and CONTRIBUTING
- fix grammar in memory README

## Testing
- `python -m compileall -q .`