### PR TITLE
Add basic CI and healthcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      app:
+        build: .
+        env:
+          AI_URL: ${{ secrets.AI_URL }}
+          AI_KEY: ${{ secrets.AI_KEY }}
+          VECTORSTORE__CONNECTION_STRING: ${{ secrets.VECTORSTORE_DSN }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          export AI_URL=$AI_URL
+          export AI_KEY=$AI_KEY
+          docker compose up --build -d
+          pytest -q
+        env:
+          AI_URL: ${{ secrets.AI_URL }}
+          AI_KEY: ${{ secrets.AI_KEY }}
+          VECTORSTORE__CONNECTION_STRING: ${{ secrets.VECTORSTORE_DSN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app ./app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,13 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/healthz", tags=["system"])
+async def healthz():
+    return {"status": "ok"}
+
+
+@app.get("/")
+async def read_root():
+    return {"message": "Hello, world!"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+  devbox-healthcheck:
+    image: curlimages/curl:7.88.1
+    command: ["sleep", "infinity"]
+    depends_on:
+      app:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://app:8080/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pytest

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_healthz():
+    response = client.get("/healthz")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- add simple FastAPI app exposing `/healthz`
- add Dockerfile and docker-compose with healthcheck service
- configure CI workflow to start the container and run tests
- include minimal pytest that checks the health endpoint

## Testing
- `ruff format app/main.py tests/test_health.py`
- `pytest -q` *(fails: command not found)*
- `docker compose up --build -d` *(fails: command not found)*